### PR TITLE
[Refactor] Remove unnecessary `require`

### DIFF
--- a/lib/circuit_switch/configuration.rb
+++ b/lib/circuit_switch/configuration.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/module/aliasing'
-
 module CircuitSwitch
   class Configuration
     CIRCUIT_SWITCH = 'circuit_switch'.freeze


### PR DESCRIPTION
This `require` has been landed in https://github.com/makicamel/circuit_switch/commit/dabb94eef9d27ddb9abcfd5037bbfd168fd67d9f.
It seems it was for `::CircuitSwitch::CircuitSwitch.alias_attribute`.

However, it is provided by ActiveModel, not ActiveSupport.
See: https://api.rubyonrails.org/classes/ActiveModel/AttributeMethods/ClassMethods.html#method-i-alias_attribute