### PR TITLE
Remove redundant verb in the initializer

### DIFF
--- a/lib/generators/circuit_switch/templates/initializer.rb
+++ b/lib/generators/circuit_switch/templates/initializer.rb
@@ -29,7 +29,7 @@ CircuitSwitch.configure do |config|
 
   # Option to contain error backtrace for report
   # You don't need backtrace when you report to some bug report tool.
-  # You may be want backtrace when report to plain feed; e.g. Slack or email.
+  # You may want backtrace when reporting to a plain feed; e.g. Slack or email.
   # config.with_backtrace = false
 
   # Allowed backtrace paths to report


### PR DESCRIPTION
A tiny correction but I bet it'll look more natural.
Thanks for sharing this gem by the way 🙂 I'll look into it further.