### PR TITLE
Remove warning related `close_if_reach_limit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Remove warning related `CircuitSwitch.open?` without `close_if_reach_limit` option.
+
 ## 0.5.0
 
 ### New features

--- a/lib/circuit_switch/builder.rb
+++ b/lib/circuit_switch/builder.rb
@@ -12,7 +12,7 @@ module CircuitSwitch
       key: nil,
       if: true,
       close_if: false,
-      close_if_reach_limit: nil,
+      close_if_reach_limit: false,
       limit_count: nil,
       initially_closed: false
     )

--- a/lib/circuit_switch/core.rb
+++ b/lib/circuit_switch/core.rb
@@ -14,7 +14,6 @@ module CircuitSwitch
         raise CircuitSwitchError.new('Can\'t set limit_count to 0 when close_if_reach_limit is true')
       end
       if close_if_reach_limit.nil?
-        Logger.new($stdout).info('Default value for close_if_reach_limit is modified from true to false at ver 0.2.0.')
         @close_if_reach_limit = false
       end
 

--- a/lib/circuit_switch/core.rb
+++ b/lib/circuit_switch/core.rb
@@ -13,9 +13,6 @@ module CircuitSwitch
       if close_if_reach_limit && run_limit_count == 0
         raise CircuitSwitchError.new('Can\'t set limit_count to 0 when close_if_reach_limit is true')
       end
-      if close_if_reach_limit.nil?
-        @close_if_reach_limit = false
-      end
 
       return self if evaluate(close_if) || !evaluate(run_if)
       return self if close_if_reach_limit && switch.reached_run_limit?(run_limit_count)


### PR DESCRIPTION
This warning is for between 0.1 to 0.2.
It is too old to show warning.

@makicamel 
How do you think about this change?