### PR TITLE
Lock sqlite3 version to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, head, truffleruby]
+        ruby: [3.1, 3.2, 3.3, head, truffleruby]
         exclude:
           - os: windows-latest
             ruby: head

--- a/circuit_switch.gemspec
+++ b/circuit_switch.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord'
   spec.add_dependency 'activesupport'
   spec.add_development_dependency 'byebug'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.4' # Following version defined by Rails. Ref https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L14
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'test-unit-rr'
 end


### PR DESCRIPTION
Since the release of sqlite3 2.x, CI breaks with the following error.
```
/opt/hostedtoolcache/Ruby/3.3.3/x64/lib/ruby/3.3.0/bundler/rubygems_integration.rb:237:in `block (2 levels) in replace_gem': Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.2-x86_64-linux-gnu. Make sure all dependencies are added to Gemfile. (LoadError)
	from /home/runner/work/circuit_switch/circuit_switch/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/sqlite3_adapter.rb:14:in `<top (required)>'
```

This error is caused by a mismatch between circuit_switch and Rails version. To avoid this error, the version of sqlite3 must be the same as the Rails definition.