### PR TITLE
chore: remove a redundant space

### DIFF
--- a/lib/generators/circuit_switch/templates/initializer.rb
+++ b/lib/generators/circuit_switch/templates/initializer.rb
@@ -15,7 +15,7 @@ CircuitSwitch.configure do |config|
   # config.report_paths = [Rails.root]
 
   # Excluded paths to report
-  # config.silent_paths =  [CIRCUIT_SWITCH]
+  # config.silent_paths = [CIRCUIT_SWITCH]
 
   # Alias column name for circuit_switches.key through alias_attribute
   # config.key_column_name = :key


### PR DESCRIPTION
This PR just remove a redundant space in the initializer template.