### PR TITLE
feat: support new stable ruby versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        ruby: [2.6, 2.7, 3.0, head]
+        ruby: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3, head]
         include:
           - { os: macos-13, ruby: '2.3' }
           - { os: macos-13, ruby: '2.4' }


### PR DESCRIPTION
This PR adds new stable ruby versions to the CI matrix: ruby 3.1, 3.2, and 3.3.
The latest version of Ruby is 3.4 preview. It's good to support those new stable versions. I use the gem `circuit_switch` on production running Ruby 3.3 already.